### PR TITLE
Fix: remove preinstall hack, declare runtime plugins as dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yachtway/eslint-config-react",
-  "version": "1.1.9",
+  "version": "1.1.11",
   "description": "The YachtWay eslint configs for Next.js project",
   "main": "index.js",
   "module": "index.js",
@@ -11,31 +11,27 @@
     "next.js"
   ],
   "scripts": {
-    "preinstall": "npm install --ignore-scripts",
     "test": "echo \"No test specified\""
   },
   "author": "YachtWay",
   "license": "ISC",
   "dependencies": {
+    "@eslint/js": "^9.29.0",
+    "@typescript-eslint/parser": "^8.53.0",
     "eslint-config-airbnb-extended": "^2.3.1",
     "eslint-config-prettier": "^9.1.0",
     "eslint-import-resolver-typescript": "^4.4.4",
-    "globals": "^16.2.0"
-  },
-  "peerDependencies": {
-    "@eslint/compat": "^1.3.1",
-    "@eslint/eslintrc": "^3.3.1",
-    "@eslint/js": "^9.29.0",
-    "@typescript-eslint/eslint-plugin": "^8.53.0",
-    "@typescript-eslint/parser": "^8.53.0",
-    "eslint": "^9.29.0",
     "eslint-plugin-import": "^2.32.0",
-    "eslint-plugin-import-x": "^4.16.1",
     "eslint-plugin-jsx-a11y": "^6.10.2",
     "eslint-plugin-prettier": "^5.5.4",
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^5.2.0",
-    "typescript": "5.8.3",
+    "globals": "^16.2.0",
     "typescript-eslint": "^8.53.0"
+  },
+  "peerDependencies": {
+    "eslint": "^9.29.0",
+    "prettier": "^3.0.0",
+    "typescript": "^5.3.0"
   }
 }


### PR DESCRIPTION
## Problem

The `"preinstall": "npm install --ignore-scripts"` script makes consumer installs non-deterministic. When a consumer installs this package as a git dependency, the script runs a second, **npm-driven** install inside the package:

- npm ≥7 auto-installs `peerDependencies`, so it fetched `typescript-eslint@^8.53.0` **fresh from the registry at install time** into a nested `node_modules` — completely outside the consumer's `yarn.lock`
- Node resolution prefers the nested copy, silently shadowing the lockfile-pinned one
- Local installs serve the git dep from yarn's cache (no nested install survives), so **local and CI lint with different versions**

This broke yachtway-frontend's Docker builds on 2026-06-02 with zero consumer changes: typescript-eslint 8.60.0 changed `@typescript-eslint/no-shadow` behavior, CI picked it up immediately, local stayed on 8.59.4.

## Fix

Everything `eslint.config.js` loads at runtime is now a regular `dependency`. Yarn classic resolves a git dep's dependencies into the host tree **pinned by the host's own yarn.lock** (it already does this for `eslint-config-airbnb-extended` etc.), so CI and local become byte-identical, and versions only move when a consumer deliberately updates its lockfile. This is also the recommended pattern for flat-config shareable configs, since they import plugin objects directly.

Only true host-owned tools remain peers: `eslint`, `prettier`, `typescript`.

## How the dependency list was derived

Traced actual module loads of `eslint-config-airbnb-extended/legacy` react configs (they lazy-load plugins via getters) + the config's own imports:

| Package | Why |
|---|---|
| `eslint-plugin-import`, `eslint-plugin-jsx-a11y`, `eslint-plugin-react`, `eslint-plugin-react-hooks` | loaded by airbnb legacy react configs |
| `typescript-eslint`, `@typescript-eslint/parser`, `@eslint/js`, `eslint-plugin-prettier` | imported directly by `eslint.config.js` |
| `@eslint/compat`, `@eslint/eslintrc`, `eslint-plugin-import-x`, `@typescript-eslint/eslint-plugin` | **never loaded** — removed (eslintrc ships with eslint; the plugin comes exact-pinned via `typescript-eslint`) |

## Verification

Packed the tarball and installed it with yarn 1 in a clean consumer containing **only the declared peers** (`eslint`, `prettier`, `typescript`):

- ✅ full lint run, no `Cannot find module` — the dependency list is complete
- ✅ no nested `node_modules` created
- ✅ `@typescript-eslint/no-shadow` fires identically to current CI (8.60.1 via normal, lockfile-governed resolution)

## Other changes

- `prettier` added as explicit peer (required by `eslint-plugin-prettier`)
- `typescript` peer loosened from exact `5.8.3` to `^5.3.0` (matches consumers; exact peer only produced install warnings)
- Version bumped to **1.1.11** — note `v1.1.10` was tagged without bumping the version field (it still says 1.1.9), this fixes the mismatch

## After merge

1. Tag `v1.1.11` on the merge commit
2. Consumers bump `#v1.1.10` → `#v1.1.11` and `yarn install` (follow-up PR ready for yachtway-frontend)

🤖 Generated with [Claude Code](https://claude.com/claude-code)